### PR TITLE
Issue 3: fix warning: interpolation only expression are deprecated

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -2,10 +2,10 @@
 data "external" "get_ip_availables" {
     program = ["bash", "${path.module}/script/get_ip_availables.sh"]
     query = {
-      subscription = "${var.subscription}"
-      resource_group = "${var.resource_group}"
-      vnet_name = "${var.vnet_name}"
-      subnet_name = "${var.subnet_name}"
+      subscription = var.subscription
+      resource_group = var.resource_group
+      vnet_name = var.vnet_name
+      subnet_name = var.subnet_name
   }
 }
 


### PR DESCRIPTION
Use new syntax to fix the warning